### PR TITLE
more verbose error strings

### DIFF
--- a/example/dart_coin_rpc_example.dart
+++ b/example/dart_coin_rpc_example.dart
@@ -9,7 +9,6 @@ void main() async {
     useSSL: false,
   );
 
-  var res = await client
-      .call('validateaddress', ["p92W3t7YkKfQEPDb7cG9jQ6iMh7cpKLvwK"]) as Map;
+  var res = await client.call('validateaddress', ["p92W3t7YkKfQEPDb7cG9jQ6iMh7cpKLvwK"]) as Map;
   assert(res["isvalid"] == true);
 }

--- a/lib/src/Exceptions/http_exception.dart
+++ b/lib/src/Exceptions/http_exception.dart
@@ -1,11 +1,16 @@
 class HTTPException implements Exception {
   int code;
   String message;
+  String methodName;
 
-  HTTPException({required this.code, required this.message});
+  HTTPException({
+    required this.code,
+    required this.message,
+    required this.methodName,
+  });
 
   @override
   String toString() {
-    return '$code: $message';
+    return '$methodName: $code: $message';
   }
 }

--- a/lib/src/Exceptions/rpc_exception.dart
+++ b/lib/src/Exceptions/rpc_exception.dart
@@ -1,7 +1,7 @@
 class RPCException implements Exception {
   int errorCode;
   String errorMsg;
-  String method;
+  String methodName;
   List params;
 
   var errorCodes = {
@@ -47,7 +47,7 @@ class RPCException implements Exception {
   RPCException({
     required this.errorCode,
     required this.errorMsg,
-    required this.method,
+    required this.methodName,
     required this.params,
   });
 
@@ -61,6 +61,6 @@ class RPCException implements Exception {
 
   @override
   String toString() {
-    return '$errorCode : $errorMsg';
+    return '$methodName(${params.toString()}): $errorCode - $errorMsg';
   }
 }

--- a/lib/src/rpcclient.dart
+++ b/lib/src/rpcclient.dart
@@ -80,8 +80,7 @@ class RPCClient {
 
     final headers = {
       'Content-Type': 'application/json',
-      'authorization':
-          'Basic ${base64.encode(utf8.encode('$username:$password'))}'
+      'authorization': 'Basic ${base64.encode(utf8.encode('$username:$password'))}'
     };
     final url = getConnectionString();
 
@@ -123,7 +122,7 @@ class RPCClient {
           throw RPCException(
             errorCode: error['code'],
             errorMsg: error['message'],
-            method: methodName,
+            methodName: methodName,
             params: params,
           );
         }
@@ -138,11 +137,13 @@ class RPCClient {
             throw HTTPException(
               code: 401,
               message: 'Unauthorized',
+              methodName: methodName,
             );
           case 403:
             throw HTTPException(
               code: 403,
               message: 'Forbidden',
+              methodName: methodName,
             );
           case 404:
             if (errorResponseBody['error'] != null) {
@@ -150,13 +151,14 @@ class RPCClient {
               throw RPCException(
                 errorCode: error['code'],
                 errorMsg: error['message'],
-                method: methodName,
+                methodName: methodName,
                 params: params,
               );
             }
             throw HTTPException(
               code: 500,
               message: 'Internal Server Error',
+              methodName: methodName,
             );
           default:
             if (errorResponseBody['error'] != null) {
@@ -164,24 +166,27 @@ class RPCClient {
               throw RPCException(
                 errorCode: error['code'],
                 errorMsg: error['message'],
-                method: methodName,
+                methodName: methodName,
                 params: params,
               );
             }
             throw HTTPException(
               code: 500,
               message: 'Internal Server Error',
+              methodName: methodName,
             );
         }
       } else if (e.type == DioExceptionType.connectionError) {
         throw HTTPException(
           code: 500,
           message: e.message ?? 'Connection Error',
+          methodName: methodName,
         );
       }
       throw HTTPException(
         code: 500,
         message: e.message ?? 'Unknown Error',
+        methodName: methodName,
       );
     }
   }


### PR DESCRIPTION
Prepend the method name to the error message. The client already knows this, and can do it themselves, but by doing it directly in the library, nothing needs to be added. Error messages are better when slightly verbose imo.